### PR TITLE
BUG: Workaround for `VariableLengthVector` addition issue

### DIFF
--- a/include/itkSpectra1DAveragingImageFilter.hxx
+++ b/include/itkSpectra1DAveragingImageFilter.hxx
@@ -90,6 +90,28 @@ operator+(const VariableLengthVector<TScalarA> & a, const Vector<TScalarB, VDime
   return result;
 }
 
+template <typename TScalarA, typename TScalarB, unsigned VDimension>
+Vector<TScalarA, VDimension>&
+operator+=(Vector<TScalarA, VDimension> & a, const VariableLengthVector<TScalarB> & b)
+{
+  for (unsigned i = 0; i < VDimension; ++i)
+  {
+    a[i] += b[i];
+  }
+  return a;
+}
+
+template <typename TScalarA, typename TScalarB, unsigned VDimension>
+VariableLengthVector<TScalarA>&
+operator+=(VariableLengthVector<TScalarA> & a, const Vector<TScalarB, VDimension> & b)
+{
+  for (unsigned i = 0; i < VDimension; ++i)
+  {
+    a[i] += b[i];
+  }
+  return a;
+}
+
 
 template <typename TInputImage, typename TOutputImage>
 void
@@ -159,7 +181,7 @@ Spectra1DAveragingImageFilter<TInputImage, TOutputImage>::GenerateData()
           ind1[0] = iIt.GetIndex()[0]; // set the index along the depth dimension
 
           OutputPixelType p = output->GetPixel(ind1);
-          p = p + iIt.Get();
+          p += iIt.Get();
           output->SetPixel(ind1, p);
 
           ++iIt;

--- a/wrapping/test/PythonSpectra1DAveragingImageFilterTest.py
+++ b/wrapping/test/PythonSpectra1DAveragingImageFilterTest.py
@@ -32,7 +32,7 @@ ImageDimension = 3
 ImageType = itk.VectorImage[itk.F, ImageDimension]
 ImageType2 = itk.VectorImage[itk.F, 2]
 
-filter = itk.Spectra1DAveragingImageFilter[ImageType, ImageType2].New()
+average_filter = itk.Spectra1DAveragingImageFilter[ImageType, ImageType2].New()
 
 for i, input_filename in enumerate(args.input_image):
     print(f"Reading {input_filename}")
@@ -40,12 +40,12 @@ for i, input_filename in enumerate(args.input_image):
     reader.SetFileName(input_filename)
     reader.Update()
     image = reader.GetOutput()
-    filter.SetInput(i, image)
+    average_filter.SetInput(i, image)
 
 print("Executing the filter")
-filter.Update()
+average_filter.Update()
 
 print(f"Writing resulting image into file: {args.output_image}")
-itk.imwrite(filter.GetOutput(), args.output_image, compression=True)
+itk.imwrite(average_filter.GetOutput(), args.output_image, compression=True)
 
 print("Test finished")


### PR DESCRIPTION
Resolves PythonSpectra1DAveragingImageFilterTest failures where
adding `itk::VariableLengthVector`s with the addition operator `+`
would sometimes result in erroneous vector math values. The `+=`
operator is implemented independent of `+` for
`itk::VariableLengthVector`s and is observed to correctly execute
element-wise vector addition.